### PR TITLE
Ideas

### DIFF
--- a/app/articles/Articles.scala
+++ b/app/articles/Articles.scala
@@ -16,6 +16,7 @@ object Articles {
 
   implicit val articleFormatter = Json.format[Article]
 
+  // NOTE: added bunch of hardcoded articles for easier checking of implemented features
   private var articles = List(
     Article(
       "First article",
@@ -26,6 +27,56 @@ object Articles {
       "Second awesome blog post",
       "Miss Catapulte",
       """You think water moves fast? You should see ice. It moves like it has a mind. Like it knows it killed the world once and got a taste for murder. After the avalanche, it took us a week to climb out. Now, I don't know exactly when we turned on each other, but I know that seven of us survived the slide... and only five made it out. Now we took an oath, that I'm breaking now. We said we'd say it was the snow that killed the other two, but it wasn't. Nature is lethal but it doesn't hold a candle to man."""
+    ),
+    Article(
+      "Three",
+      "Darth Vader",
+      """I am your father!"""
+    ),
+    Article(
+      "Four",
+      "Luke Skywalker",
+      """Noooooo!"""
+    ),
+    Article(
+      "Five",
+      "John Nada",
+      """I have come here to chew bubblegum and kick ass... and I'm all out of bubblegum."""
+    ),
+    Article(
+      "Six",
+      "Leonidas",
+      """This is Sparta!"""
+    ),
+    Article(
+      "Seven",
+      "Braveheart",
+      """They may take our lives, but they'll never take our freedom!"""
+    ),
+    Article(
+      "Eight",
+      "Maximus",
+      """My name is Maximus Decimus Meridius, commander of the Armies of the North, General of the Felix Legions and loyal servant to the true emperor, Marcus Aurelius. Father to a murdered son, husband to a murdered wife. And I will have my vengeance, in this life or the next."""
+    ),
+    Article(
+      "Nine",
+      "Han Solo",
+      """Chewie, we're home."""
+    ),
+    Article(
+      "Ten",
+      "Harry Callahan",
+      """Go ahead, make my day."""
+    ),
+    Article(
+      "Eleven",
+      "Leia",
+      """Help me, Obi-Wan Kenobi. You're my only hope."""
+    ),
+    Article(
+      "Twelve",
+      "Terminator",
+      """Hasta la vista, baby."""
     )
   )
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -5,6 +5,7 @@
     <head>
         @* Here's where we render the page title `String`. *@
         <title>@title</title>
+        <link href='http://fonts.googleapis.com/css?family=Roboto:400,600,700,300&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
         <link rel="stylesheet" media="screen" href="@routes.Assets.versioned("stylesheets/main.css")">
         <link rel="shortcut icon" type="image/png" href="@routes.Assets.versioned("images/favicon.png")">
 

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -47,6 +47,11 @@ const Article = React.createClass({
 });
 
 const ArticlesList = React.createClass({
+    getInitialState() {
+        // TODO: not finished
+        //return { classes: ['rpc-articles-list', 'rpc-only-titles'] };
+        return { classes: ['rpc-articles-list'] };
+    },
     render() {
         const list =
             this.props.articles.length
@@ -60,7 +65,7 @@ const ArticlesList = React.createClass({
                 : <h2>No articles</h2>;
 
         return (
-            <div className="rpc-articles-list">
+            <div className={this.state.classes.join(' ')}>
                 { list }
             </div>
         );
@@ -68,7 +73,7 @@ const ArticlesList = React.createClass({
 });
 
 /**
- * Filter articles by a simple title partial match checking. TODO: Also the filter can be cleared.
+ * Filter articles by a simple title partial match checking. Also the filter can be cleared.
  */
 const FilterByTitle = React.createClass({
     getInitialState() {
@@ -101,7 +106,7 @@ const FilterByTitle = React.createClass({
 });
 
 /**
- * TODO: Filter articles by simple title partial match checking. Also filter can be cleared.
+ * Filter articles by simple title partial match checking. Also filter can be cleared.
  */
 const ContentToggler = React.createClass({
     render() {
@@ -121,11 +126,14 @@ const ArticlesBox = React.createClass({
                 <h1>Articles</h1>
                 <div className="rpc-articles-settings">
                     <FilterByTitle articles={this.props.articles} filter={this.props.filter} clearFilter={this.props.clearFilter} />
-                    <ContentToggler toggleContent={this.props.toggleContent} />
+                    {/*
+                      TODO: not finished
+                      <ContentToggler toggleContent={this.props.toggleContent} />
+                    */}
                 </div>
-                <ArticlesList articles={this.props.articles} />
+                <ArticlesList articles={this.props.articles} articlesListClasses={"TODO"} />
                 <hr />
-                <h4>Articles are sponsored by <a href='http://slipsum.com'>SAMUEL L. IPSUM</a></h4>
+                <h4>Some articles are sponsored by <a href='http://slipsum.com'>SAMUEL L. IPSUM</a></h4>
             </div>
         );
     }

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,3 +1,7 @@
+// NOTE: currently it is advised to use ES6 classes as a replacement for older createClass.
+// Babel is used anyway so it would not be a problem. Set is as a TODO for future.
+// Also adding a build-step (Webpack) would be a good choice as app grows to split this file into smaller ones
+
 
 const NewArticleForm = React.createClass({
     getInitialState() {
@@ -20,10 +24,10 @@ const NewArticleForm = React.createClass({
     },
     render() {
         return (
-           <div>
-               <p>Title : <input type='text' value={this.state.title} onChange={this.handleTitleChange} /></p>
-               <p>Author : <input type='text' value={this.state.author} onChange={this.handleAuthorChange} /></p>
-               <p>Content : <textarea value={this.state.content} onChange={this.handleContentChange} /></p>
+           <div className="rpc-form">
+               <p><label>Title:</label> <input type='text' value={this.state.title} onChange={this.handleTitleChange} /></p>
+               <p><label>Author:</label> <input type='text' value={this.state.author} onChange={this.handleAuthorChange} /></p>
+               <p><label>Content:</label> <textarea value={this.state.content} onChange={this.handleContentChange} /></p>
                <button onClick={this.postNewArticle}>Publish</button>
            </div>
         );
@@ -33,7 +37,7 @@ const NewArticleForm = React.createClass({
 const Article = React.createClass({
     render() {
         return (
-           <div>
+           <div className="rpc-article">
                <h3>{this.props.title}</h3>
                <p>Author: {this.props.author}</p>
                <p>{this.props.content}</p>
@@ -56,9 +60,56 @@ const ArticlesList = React.createClass({
                 : <h2>No articles</h2>;
 
         return (
-            <div>
+            <div className="rpc-articles-list">
                 { list }
             </div>
+        );
+    }
+});
+
+/**
+ * Filter articles by a simple title partial match checking. TODO: Also the filter can be cleared.
+ */
+const FilterByTitle = React.createClass({
+    getInitialState() {
+        return {filterText: ""}
+    },
+    clearValue(event) {
+        this.props.clearFilter(event);
+
+        this.setState((prevState) => ({
+            filterText: ""
+        }));
+    },
+    updateValue(event) {
+        var val = event.target.value;
+
+        this.props.filter(event);
+
+        this.setState((prevState) => ({
+            filterText: val
+        }));
+    },
+    render() {
+        return (
+            <div className="rpc-article-filter">
+                 <input type="text" placeholder="Filter by title" value={this.state.filterText} onChange={this.updateValue} />
+                 <button onClick={this.clearValue}>Clear</button>
+            </div>
+        );
+    }
+});
+
+/**
+ * TODO: Filter articles by simple title partial match checking. Also filter can be cleared.
+ */
+const ContentToggler = React.createClass({
+    render() {
+        return (
+            <label className="rpc-filter-clear">
+                <input type="checkbox" onChange={this.props.toggleContent} />
+                <span>Toggle content</span>
+            </label>
         );
     }
 });
@@ -66,8 +117,12 @@ const ArticlesList = React.createClass({
 const ArticlesBox = React.createClass({
     render() {
         return (
-            <div className='split-left'>
-                <h1>Articles :</h1>
+            <div className='rpc-split-left'>
+                <h1>Articles</h1>
+                <div className="rpc-articles-settings">
+                    <FilterByTitle articles={this.props.articles} filter={this.props.filter} clearFilter={this.props.clearFilter} />
+                    <ContentToggler toggleContent={this.props.toggleContent} />
+                </div>
                 <ArticlesList articles={this.props.articles} />
                 <hr />
                 <h4>Articles are sponsored by <a href='http://slipsum.com'>SAMUEL L. IPSUM</a></h4>
@@ -79,8 +134,8 @@ const ArticlesBox = React.createClass({
 const NewArticleBox = React.createClass({
     render() {
         return (
-            <div className='split-right'>
-                <h1>New article :</h1>
+            <div className='rpc-split-right'>
+                <h1>New article</h1>
                 <NewArticleForm postNewArticle={this.props.postNewArticle} />
             </div>
         );
@@ -92,7 +147,9 @@ const TopLevelBox = React.createClass({
         this.getArticlesFromBackend()
     },
     getInitialState() {
-        return { articles: [] };
+        // NOTE: added cache here to not make additional ajax call after filtering to rest articles list
+        // More sofisticated mechanism could be used here in real scale application
+        return { articles: [], articlesCache: [] };
     },
     getArticlesFromBackend() {
         $.ajax({
@@ -100,7 +157,10 @@ const TopLevelBox = React.createClass({
             dataType: 'json',
             type: 'GET',
             success: function(articles) {
-                this.setState({ articles });
+                this.setState((prevState) => ({
+                    articles: articles,
+                    articlesCache: articles
+                }));
             }.bind(this),
             error: function(xhr, status, err) {
                 console.error(this.props.url, status, err.toString());
@@ -115,22 +175,56 @@ const TopLevelBox = React.createClass({
             data: JSON.stringify(newArticle),
             success: function() {
                 successCallback();
-                const articles = this.state.articles;
-                this.setState({ articles: articles.concat([newArticle]) });
+                const articles = this.state.articlesCache;
+                this.setState((prevState) => ({
+                    articles: articles.concat([newArticle]),
+                    articlesCache: articles.concat([newArticle])
+                }));
+                //this.setState({ articlesCache: articles.concat([newArticle]) });
             }.bind(this),
             error: function(xhr, status, err) {
                 console.error(this.props.url, status, err.toString());
             }.bind(this)
         });
     },
-    render() {
-        const height = $(window).height();
-        const width = $(window).width();
+    /**
+     * Simple partial match of title and typed phrase is used for filtering.
+     */
+    filterArticlesByTitle(event) {
+        const articles = this.state.articlesCache;
+        var title = event.target.value;
 
+        this.setState((prevState) => ({
+            articles: articles.filter((article) => {
+                return (article.title.indexOf(title) !== -1)
+            })
+        }));
+    },
+    /**
+     * Just for user convenience a helper to clear typed filter text.
+     */
+    clearTitleFilter(event) {
+        const articles = this.state.articlesCache;
+        var toggle = event.target.value;
+
+        this.setState((prevState) => ({
+            articles: articles
+        }));
+    },
+    /**
+     * TODO: Another convenience utility for easier scanning only article headers.
+     */
+    toggleContent(event) {
+        console.log("TODO: toggle change: ");
+    },
+    render() {
+        // NOTE: removed width & height calculations,
+        // as it is not needed anymore,
+        // moved to CSS and added basic responsivness
         return (
-           <div style={{ height, width }}>
-               <ArticlesBox articles={this.state.articles} />
+           <div className="rpc-app">
                <NewArticleBox postNewArticle={this.postNewArticle} />
+               <ArticlesBox articles={this.state.articles} filter={this.filterArticlesByTitle} clearFilter={this.clearTitleFilter} />
            </div>
         );
     }

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -60,7 +60,7 @@ const ArticlesList = React.createClass({
                 : <h2>No articles</h2>;
 
         return (
-            <div className="rpc-articles-list"}>
+            <div className="rpc-articles-list">
                 { list }
             </div>
         );

--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -47,11 +47,6 @@ const Article = React.createClass({
 });
 
 const ArticlesList = React.createClass({
-    getInitialState() {
-        // TODO: not finished
-        //return { classes: ['rpc-articles-list', 'rpc-only-titles'] };
-        return { classes: ['rpc-articles-list'] };
-    },
     render() {
         const list =
             this.props.articles.length
@@ -65,7 +60,7 @@ const ArticlesList = React.createClass({
                 : <h2>No articles</h2>;
 
         return (
-            <div className={this.state.classes.join(' ')}>
+            <div className="rpc-articles-list"}>
                 { list }
             </div>
         );
@@ -105,20 +100,6 @@ const FilterByTitle = React.createClass({
     }
 });
 
-/**
- * Filter articles by simple title partial match checking. Also filter can be cleared.
- */
-const ContentToggler = React.createClass({
-    render() {
-        return (
-            <label className="rpc-filter-clear">
-                <input type="checkbox" onChange={this.props.toggleContent} />
-                <span>Toggle content</span>
-            </label>
-        );
-    }
-});
-
 const ArticlesBox = React.createClass({
     render() {
         return (
@@ -126,12 +107,8 @@ const ArticlesBox = React.createClass({
                 <h1>Articles</h1>
                 <div className="rpc-articles-settings">
                     <FilterByTitle articles={this.props.articles} filter={this.props.filter} clearFilter={this.props.clearFilter} />
-                    {/*
-                      TODO: not finished
-                      <ContentToggler toggleContent={this.props.toggleContent} />
-                    */}
                 </div>
-                <ArticlesList articles={this.props.articles} articlesListClasses={"TODO"} />
+                <ArticlesList articles={this.props.articles} />
                 <hr />
                 <h4>Some articles are sponsored by <a href='http://slipsum.com'>SAMUEL L. IPSUM</a></h4>
             </div>
@@ -188,7 +165,6 @@ const TopLevelBox = React.createClass({
                     articles: articles.concat([newArticle]),
                     articlesCache: articles.concat([newArticle])
                 }));
-                //this.setState({ articlesCache: articles.concat([newArticle]) });
             }.bind(this),
             error: function(xhr, status, err) {
                 console.error(this.props.url, status, err.toString());
@@ -213,17 +189,10 @@ const TopLevelBox = React.createClass({
      */
     clearTitleFilter(event) {
         const articles = this.state.articlesCache;
-        var toggle = event.target.value;
 
         this.setState((prevState) => ({
             articles: articles
         }));
-    },
-    /**
-     * TODO: Another convenience utility for easier scanning only article headers.
-     */
-    toggleContent(event) {
-        console.log("TODO: toggle change: ");
     },
     render() {
         // NOTE: removed width & height calculations,

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -24,13 +24,18 @@ html {
 
 
 
+/* Simple trick to force right column to have 100% height of all content
+ * without changing all HTML layout and going into absolutes or flexbox */
+.rpc-app {
+    display: table;
+    height: 100%;
+}
 
 
 /* Split page */
 
 .rpc-split-left {
       height: 100%;
-      overflow: auto;
       float: left;
       width: calc(100% - 25rem);
       background: #f5f5f5;
@@ -120,6 +125,10 @@ html {
 
 /* Very basic responsivness support */
 @media screen and (max-width: 850px) {
+    .rpc-app {
+        display: block;
+    }
+
     .rpc-split-right,
     .rpc-split-left {
         float: left;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -1,14 +1,128 @@
-/* Split page */
+/* Basic reset, font and layouting
+ * rpc- is a prefix to avoid potential collisions,
+ * as the app will grow and some external components could be used
+ *
+ * It is rather good idea to use LESS / SASS and split it for smaller parts / files in future.
+ */
 
-.split-left {
-    height: 100%;
-    overflow: auto;
-    float: left;
-    width: 70%;
+html, body, div, p {
+    margin: 0;
+    padding: 0;
 }
 
-.split-right {
-    float: right;
-    width: 30%;
+* {
+    box-sizing: border-box;
+	  font-family: Roboto, sans-serif;
+	  font-weight: 400;
+}
+
+html {
+    font-size: 1rem;
     height: 100%;
+    width: 100%;
+}
+
+
+
+
+
+/* Split page */
+
+.rpc-split-left {
+      height: 100%;
+      overflow: auto;
+      float: left;
+      width: calc(100% - 25rem);
+      background: #f5f5f5;
+      padding: 1rem;
+}
+
+.rpc-articles-settings {
+    background: #ccc;
+}
+
+.rpc-article-filter {
+    padding: 0.5rem;
+    display: inline-block;
+}
+
+.rpc-article-filter input[type="text"] {
+    width: 300px;
+    display: inline-block;
+    border: 1px solid #333;
+    padding: 0.5rem;
+}
+
+.rpc-article-filter button {
+    color: #fff;
+    background: #333;
+    border: 1px solid #333;
+    padding: 0.5rem;
+    cursor: pointer;
+}
+
+.rpc-filter-clear {
+    margin-left: 1rem;
+}
+
+/* Article */
+.rpc-article {
+    margin-bottom: 3rem;
+}
+
+
+
+
+
+/*==== Adding articles ====*/
+
+.rpc-split-right {
+    float: right;
+    width: 25rem;
+    height: 100%;
+    background: #2a363e;
+    padding: 1rem;
+}
+
+.rpc-split-right h1 {
+    color: #fff;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid #222;
+}
+
+.rpc-form label {
+    color: #fff;
+}
+
+.rpc-form input,
+.rpc-form textarea {
+    display: block;
+    width: 100%;
+    border: 1px solid #333;
+    padding: 0.5rem;
+}
+
+.rpc-form button {
+    display: block;
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #333;
+    cursor: pointer;
+    color: #fff;
+    background: #e25758;
+}
+
+
+
+
+
+
+
+/* Very basic responsivness support */
+@media screen and (max-width: 850px) {
+    .rpc-split-right,
+    .rpc-split-left {
+        float: left;
+        width: 100%;
+    }
 }

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -29,6 +29,7 @@ html {
 .rpc-app {
     display: table;
     height: 100%;
+    width: 100%;
 }
 
 
@@ -73,6 +74,26 @@ html {
 /* Article */
 .rpc-article {
     margin-bottom: 3rem;
+}
+
+
+/* Show only titles */
+.rpc-only-titles {
+    margin-top: 1rem;
+}
+
+.rpc-only-titles .rpc-article {
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+    background: #fff;
+}
+
+.rpc-only-titles h3 {
+    margin: 0;
+}
+
+.rpc-only-titles p {
+    display: none;
 }
 
 


### PR DESCRIPTION
Simple filtering articles list by partial title match + simple styling. I have articles content visibility toggling in progress, but removed it for now as it is just an usability sugar and wanted a proper implementation or none.

Ideas for future (some of which I already did some research):

- simple paging or lazy loading in batches
- replacing older createClass by ES6 class usage as currently suggested by React team
- keeping hardcoded articles in e.g. yaml file and loading it on Play's instance start
- simple MongoDB integration
- adding build-step with Webpack and LESS / SASS integration and split files for smaller parts
- full separation of React front-end and Play back-end by using simple Node.js front server that wold fetch JSONs from Play and serve for React. That would allow in future e.g. make React backend rendering support for performance, SEO, etc.